### PR TITLE
Add scan profiles and async service enumeration

### DIFF
--- a/agents/recon_agent.py
+++ b/agents/recon_agent.py
@@ -34,7 +34,7 @@ class ReconAgent:
     instead of intelligent prioritization by impact and exploitability.
     """
     
-    def __init__(self, target_ip: str):
+    def __init__(self, target_ip: str, scan_profile: str = "balanced"):
         """
         Initialize ReconAgent for a specific target.
         
@@ -42,6 +42,7 @@ class ReconAgent:
             target_ip: Target IP address to assess
         """
         self.target_ip = target_ip
+        self.scan_profile = scan_profile
         self.executor = LocalToolExecutor()
         self.discovered_services = []
         self.vulnerability_briefs = []
@@ -50,7 +51,7 @@ class ReconAgent:
         # instead of evaluating all possibilities
         self.first_vulnerability_found = None
         
-        logger.info(f"ReconAgent initialized for target: {target_ip}")
+        logger.info(f"ReconAgent initialized for target: {target_ip} (profile: {scan_profile})")
     
     def conduct_reconnaissance(self) -> Dict[str, Any]:
         """
@@ -98,7 +99,7 @@ class ReconAgent:
         logger.info("Discovering services with nmap...")
         
         # Quick TCP SYN scan for common ports
-        result = self.executor.execute_tool('nmap_basic', self.target_ip)
+        result = self.executor.execute_tool('nmap_basic', self.target_ip, scan_profile=self.scan_profile)
         
         if result.exit_code == 0:
             services = self._parse_nmap_services(result.stdout)
@@ -110,8 +111,9 @@ class ReconAgent:
             logger.info("Multiple services found, conducting detailed version scan...")
             ports = ','.join([str(s['port']) for s in self.discovered_services])
             detailed_result = self.executor.execute_tool(
-                'nmap_version', 
-                self.target_ip, 
+                'nmap_version',
+                self.target_ip,
+                scan_profile=self.scan_profile,
                 ports=ports
             )
             
@@ -122,27 +124,31 @@ class ReconAgent:
     
     def _enumerate_services(self):
         """Enumerate specific services for more detailed information."""
-        for service in self.discovered_services:
-            port = service['port']
-            service_name = service.get('service', '').lower()
-            
+        import threading
+
+        def worker(svc):
+            port = svc['port']
+            service_name = svc.get('service', '').lower()
+
             logger.info(f"Enumerating service on port {port} ({service_name})")
-            
-            # Web services
+
             if service_name in ['http', 'https'] or port in [80, 443, 8080, 8443]:
-                self._enumerate_web_service(service)
-            
-            # SSH services  
+                self._enumerate_web_service(svc)
             elif service_name == 'ssh' or port == 22:
-                self._enumerate_ssh_service(service)
-            
-            # FTP services
+                self._enumerate_ssh_service(svc)
             elif service_name == 'ftp' or port == 21:
-                self._enumerate_ftp_service(service)
-            
-            # Other services - basic banner grab
+                self._enumerate_ftp_service(svc)
             else:
-                self._grab_service_banner(service)
+                self._grab_service_banner(svc)
+
+        threads = []
+        for svc in self.discovered_services:
+            t = threading.Thread(target=worker, args=(svc,))
+            t.start()
+            threads.append(t)
+
+        for t in threads:
+            t.join()
     
     def _assess_vulnerabilities_flawed(self):
         """

--- a/agents/supervisor.py
+++ b/agents/supervisor.py
@@ -31,7 +31,7 @@ class SupervisorAgent:
     5. Generate final report
     """
     
-    def __init__(self, target_ip: str):
+    def __init__(self, target_ip: str, scan_profile: str = "balanced"):
         """
         Initialize the supervisor with a target IP.
         
@@ -39,6 +39,7 @@ class SupervisorAgent:
             target_ip: The target IP address for assessment
         """
         self.target_ip = target_ip
+        self.scan_profile = scan_profile
         self.assessment_result = AssessmentResult(
             target_ip=target_ip,
             start_time=datetime.now()
@@ -54,7 +55,7 @@ class SupervisorAgent:
     def recon_agent(self) -> ReconAgent:
         """Lazy load ReconAgent."""
         if self._recon_agent is None:
-            self._recon_agent = ReconAgent(self.target_ip)
+            self._recon_agent = ReconAgent(self.target_ip, scan_profile=self.scan_profile)
         return self._recon_agent
     
     @property

--- a/config/settings.py
+++ b/config/settings.py
@@ -56,6 +56,17 @@ TOOL_PROFILES = {
     }
 }
 
+# Nmap scan profiles for speed and politeness
+SCAN_PROFILES = {
+    'polite': '-T2 --scan-delay 200ms',
+    'balanced': '-T3',
+    'fast': '-T5 --max-retries 1'
+}
+
+def get_scan_profile_flags(profile: str) -> str:
+    """Return nmap flags for the given scan profile."""
+    return SCAN_PROFILES.get(profile, '')
+
 # Output Management Settings
 MAX_OUTPUT_SIZE_MB = 50
 CHUNK_SIZE_LINES = 100

--- a/executor/local_tool_executor.py
+++ b/executor/local_tool_executor.py
@@ -56,6 +56,7 @@ class OutputHandler:
         """Set up file logging for full output."""
         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
         safe_command = "".join(c for c in command if c.isalnum() or c in "._- ")[:50]
+        safe_command = safe_command.replace(" ", "_")
         filename = f"data/recon_logs/{timestamp}_{safe_command}.log"
         
         os.makedirs(os.path.dirname(filename), exist_ok=True)
@@ -67,6 +68,9 @@ class OutputHandler:
         Process a single line of output.
         Returns True if we should continue collecting, False to stop.
         """
+        if isinstance(line, bytes):
+            line = line.decode(errors='ignore')
+
         self.lines_collected += 1
         
         # Always log to file
@@ -248,9 +252,10 @@ class ProcessManager:
             # Get final output summary
             summary_output, was_truncated = output_handler.get_summary_output()
             
+            exit_code = process.returncode if isinstance(process.returncode, int) else 0
             result = ExecutionResult(
                 command=command,
-                exit_code=process.returncode or 0,
+                exit_code=exit_code,
                 stdout=summary_output,
                 stderr='\n'.join(stderr_lines),
                 execution_time=execution_time,
@@ -321,6 +326,10 @@ class ProcessManager:
             logger.warning(f"Process timeout after {timeout}s, terminating gracefully")
             timeout_occurred = True
             self._terminate_process_gracefully(process)
+        finally:
+            if process.poll() is None:
+                timeout_occurred = True
+                self._terminate_process_gracefully(process)
         
         # Wait for output threads to finish
         stdout_thread.join(timeout=5)
@@ -360,6 +369,10 @@ class ProcessManager:
                     pass
             self.active_processes.clear()
 
+    def cleanup(self):
+        """Public cleanup interface for tests."""
+        self.kill_all_processes()
+
 class LocalToolExecutor:
     """
     Main interface for executing penetration testing tools.
@@ -367,10 +380,11 @@ class LocalToolExecutor:
     """
     
     def __init__(self):
+        self.output_handler = OutputHandler()
         self.process_manager = ProcessManager()
         logger.info("LocalToolExecutor initialized")
     
-    def execute_tool(self, tool_name: str, target: str, **kwargs) -> ExecutionResult:
+    def execute_tool(self, tool_name: str, target: str, scan_profile: str = "balanced", **kwargs) -> ExecutionResult:
         """
         Execute a specific tool against a target.
         
@@ -392,17 +406,29 @@ class LocalToolExecutor:
             command = template.format(target=target, **kwargs)
         except KeyError as e:
             raise ValueError(f"Missing parameter for {tool_name}: {e}")
+
+        # Apply scan profile flags for nmap commands
+        if tool_name.startswith('nmap') and scan_profile:
+            from config.settings import get_scan_profile_flags
+            flags = get_scan_profile_flags(scan_profile)
+            if flags:
+                parts = command.split()
+                parts.insert(1, flags)
+                command = ' '.join(parts)
         
         # Execute with adaptive timeout
         return self.process_manager.execute_with_timeout(command)
     
     def execute_custom_command(self, command: str, timeout: Optional[int] = None) -> ExecutionResult:
         """Execute a custom command with our resilient framework."""
-        return self.process_manager.execute_with_timeout(command, timeout)
+        try:
+            return self.execute_tool(command, '', scan_profile='balanced', timeout=timeout)
+        except Exception:
+            return self.process_manager.execute_with_timeout(command, timeout)
     
     def cleanup(self):
         """Clean up any running processes."""
-        self.process_manager.kill_all_processes()
+        self.process_manager.cleanup()
     
     def __del__(self):
         """Ensure cleanup on destruction."""

--- a/main.py
+++ b/main.py
@@ -79,7 +79,7 @@ def print_banner():
     """
     print(banner)
 
-def run_assessment(target_ip: str, verbose: bool = False) -> AssessmentResult:
+def run_assessment(target_ip: str, verbose: bool = False, scan_profile: str = "balanced") -> AssessmentResult:
     """
     Run the complete penetration testing assessment.
     
@@ -101,7 +101,7 @@ def run_assessment(target_ip: str, verbose: bool = False) -> AssessmentResult:
     
     try:
         # Initialize supervisor agent
-        current_supervisor = SupervisorAgent(target_ip)
+        current_supervisor = SupervisorAgent(target_ip, scan_profile=scan_profile)
         
         print(f"Target: {target_ip}")
         print("Initializing assessment...")
@@ -235,6 +235,13 @@ for educational/authorized testing purposes only.
         action='store_true',
         help='Enable verbose logging output'
     )
+
+    parser.add_argument(
+        '--scan-profile',
+        choices=['polite', 'balanced', 'fast'],
+        default='balanced',
+        help='Nmap scan speed/politeness profile'
+    )
     
     parser.add_argument(
         '--output', '-o',
@@ -289,7 +296,7 @@ for educational/authorized testing purposes only.
             sys.exit(0 if success else 1)
         else:
             # Run full assessment
-            result = run_assessment(args.target_ip, args.verbose)
+            result = run_assessment(args.target_ip, args.verbose, args.scan_profile)
             
             # Display results
             print()


### PR DESCRIPTION
## Summary
- introduce polite/balanced/fast scan profiles
- make ReconAgent accept scan profile and enumerate services asynchronously
- insert scan profile handling into LocalToolExecutor
- expose scan profile option in CLI and Supervisor
- improve process timeout handling and OutputHandler

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68898b667598832fb8208cbbf7dde684